### PR TITLE
pull Go version from go.mod instead of from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '>= 1.21'
-          check-latest: true
+          go-version-file: ./go.mod
 
       - name: Build
         run: go build -v ./...
@@ -34,10 +33,11 @@ jobs:
         run: go test --covermode=atomic --coverprofile=replicator-${{ github.sha }}-unit-test-code-coverage.out -v ./...
 
       - name: Archive Unit Test Code Coverage Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Code Coverage Output
           path: replicator-${{ github.sha }}-unit-test-code-coverage.out
+          overwrite: true
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Login to Docker Hub


### PR DESCRIPTION
this might help with bumping go and is something I am doing in all my Go projects