### PR TITLE
[TNZ-100213] Bump Go toolchain to 1.26.3 ai-assisted=yes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/pivotal-cf/replicator
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26.3
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.3


### PR DESCRIPTION
Addresses CVE-2026-33814, CVE-2026-33811, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499, CVE-2026-42501 in stdlib.

replicator has no net/http or net imports, so all CVEs are code_not_present. Toolchain bump is for hygiene and ensures future scans show a non-vulnerable Go version.